### PR TITLE
Update webxr-polyfill.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "cross-env NODE_ENV=production rollup -c rollup.config.js",
     "minify": "cross-env NODE_ENV=production rollup -c rollup-minify.config.js",
-    "start": "npm run build && http-server ."
+    "start": "npm run build && http-server . -c-1"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
   },
   "dependencies": {
     "gl-matrix": "^2.5.1",
-    "webxr-polyfill": "git://github.com/blairmacintyre/webxr-polyfill.git#minimal-for-app"
+    "webxr-polyfill": "git://github.com/takahirox/webxr-polyfill.git#ForWebXRViewer"
   }
 }


### PR DESCRIPTION
I've been working on updating to support the newest WebXR API in this [repository](https://github.com/takahirox/webxr-ios-js/tree/PolyfillUpdateWIP) and ready to submit the change.

But I realized the change is very [huge](https://github.com/MozillaReality/webxr-ios-js/compare/develop...takahirox:PolyfillUpdateWIP) and I'm sure review will be hard.

So I decided to send small PRs one by one. This PR is the first one. Updating webxr-polyfill.js.

We can't directly use the official [webxr-polyfill.js](https://github.com/immersive-web/webxr-polyfill) yet because

- `requestSession()` doesn't take the second argument yet (https://github.com/immersive-web/webxr-polyfill/pull/95)
- It includes huge Cardboard module which we don't need (https://github.com/immersive-web/webxr-polyfill/issues/56)
- It doesn't fully support `getPose()` yet (https://github.com/immersive-web/webxr-polyfill/issues/92)

The PRs and issues are already opened for the problems so maybe we will be able to directly load the official polyfill at some point but we need our own fork for now. Then I made our own, based on the newest webxr-polyfill.js but I resolved the problems, at https://github.com/takahirox/webxr-polyfill/tree/ForWebXRViewer

Notes
- I forked my working branch from `develop` so sending PR to `develop`
- webxr.js and the examples won't work until we merge the all PRs I'll send one by one later