### PR TITLE
Update ARKitDevice.js to follow the latest WebXR API spec

### DIFF
--- a/src/arkit/ARKitDevice.js
+++ b/src/arkit/ARKitDevice.js
@@ -125,7 +125,7 @@ export default class ARKitDevice extends XRDevice {
 		let watchResult = await this._arKitWrapper.watch(ARKitOptions).then((results) => {
 			// Note: Commenting out options.outputContext for now because
 			//       I don't know what it's used for.
-			const session = new Session(/*options.outputContext ||*/ null)
+			const session = new Session()
 			this._sessions.set(session.id, session)
 			this._activeSession = session
 
@@ -303,9 +303,8 @@ export default class ARKitDevice extends XRDevice {
 
 let SESSION_ID = 100
 class Session {
-	constructor(outputContext){
+	constructor(){
 		this.ended = null // boolean
-		this.outputContext = outputContext // XRPresentationContext
 		this.baseLayer = null // XRWebGLLayer
 		this.id = ++SESSION_ID
 	}

--- a/src/arkit/ARKitDevice.js
+++ b/src/arkit/ARKitDevice.js
@@ -204,9 +204,11 @@ export default class ARKitDevice extends XRDevice {
 						resolve(that._eyeLevelMatrix) 
 					})
 					return
-				case 'stage': // @TODO: Update
-					//return that._stageMatrix
-					reject(new Error('stage not supported', type))
+				case 'local-floor':
+				case 'bounded-floor':
+				case 'unbounded':
+					reject(new Error('not supported', type))
+					return
 				default:
 					reject(new Error('Unsupported frame of reference type', type))
 			}

--- a/src/arkit/ARKitDevice.js
+++ b/src/arkit/ARKitDevice.js
@@ -206,6 +206,13 @@ export default class ARKitDevice extends XRDevice {
 					return
 				case 'local-floor':
 				case 'bounded-floor':
+
+				// @TODO: Support unbounded reference space.
+				// @TODO: Support reset event.
+				//        In ARKit, the native origin can change as the user moves around.
+				//        In unbounded, the space origin can change. But in other space
+				//        such as local and local-floor, if the origin changes, a reset event should
+				//        be triggered on the coordinate system (per the spec).
 				case 'unbounded':
 					reject(new Error('not supported', type))
 					return

--- a/src/arkit/ARKitDevice.js
+++ b/src/arkit/ARKitDevice.js
@@ -7,7 +7,7 @@
  */
 import * as mat4 from 'gl-matrix/src/gl-matrix/mat4'
 
-import PolyfilledXRDevice from 'webxr-polyfill/src/devices/PolyfilledXRDevice'
+import XRDevice from 'webxr-polyfill/src/devices/XRDevice'
 
 import {throttle, throttledConsoleLog} from '../lib/throttle.js'
 
@@ -15,7 +15,7 @@ import ARKitWrapper from './ARKitWrapper.js'
 import ARKitWatcher from './ARKitWatcher.js'
 
 
-export default class ARKitDevice extends PolyfilledXRDevice {
+export default class ARKitDevice extends XRDevice {
 	constructor(global){
 		super(global)
 		this._throttledLogPose = throttle(this.logPose, 1000)
@@ -26,9 +26,16 @@ export default class ARKitDevice extends PolyfilledXRDevice {
 		// A div prepended to body children that will contain the session layer
 		this._wrapperDiv = document.createElement('div')
 		this._wrapperDiv.setAttribute('class', 'arkit-device-wrapper')
-		document.addEventListener('DOMContentLoaded', ev => {
-			document.body.insertBefore(this._wrapperDiv, document.body.firstChild || null)
-		})
+
+		const insertWrapperDiv = () => {
+			document.body.insertBefore(this._wrapperDiv, document.body.firstChild || null);
+		};
+
+		if (document.body) {
+			insertWrapperDiv();
+		} else {
+			document.addEventListener('DOMContentLoaded', ev => insertWrapperDiv);
+		}
 
 		this._headModelMatrix = mat4.create() // Model and view matrix are the same
 		this._projectionMatrix = mat4.create()
@@ -75,15 +82,13 @@ export default class ARKitDevice extends PolyfilledXRDevice {
 	get depthFar(){ return this._depthFar }
 	set depthFar(val){ this._depthFar = val }
 
-	supportsSession(options={}){
-		// true if:
-		//  not immersive
-		return !options.hasOwnProperty("immersive") || !options.immersive
+	isSessionSupported(mode){
+		return mode === 'inline' || mode === 'immersive-ar';
 	}
 
-	async requestSession(options={}){
-		if(!this.supportsSession(options)){
-			console.error('Invalid session options', options)
+	async requestSession(mode, xrSessionInit={}){
+		if(!this.isSessionSupported(mode)){
+			console.error('Invalid session mode', mode)
 			return Promise.reject()
 		}
 		if(!this._arKitWrapper){
@@ -95,15 +100,21 @@ export default class ARKitDevice extends PolyfilledXRDevice {
 			return Promise.reject()
 		}
 
+		const requiredFeatures = xrSessionInit.requiredFeatures || [];
+		const optionalFeatures = xrSessionInit.optionalFeatures || [];
+
 		var ARKitOptions = {}
-		if (options.hasOwnProperty("worldSensing")) {
-			ARKitOptions.worldSensing = options.worldSensing
+		if (requiredFeatures.indexOf("worldSensing") >= 0 ||
+			optionalFeatures.indexOf("worldSensing") >= 0) {
+			ARKitOptions.worldSensing = true;
 		}
-		if (options.hasOwnProperty("computerVision")) {
-			ARKitOptions.videoFrames = options.useComputerVision
+		if (requiredFeatures.indexOf("computerVision") >= 0 ||
+			optionalFeatures.indexOf("computerVision") >= 0) {
+			ARKitOptions.videoFrames = true;
 		}
-		if (options.hasOwnProperty("alignEUS")) {
-			ARKitOptions.alignEUS = options.alignEUS
+		if (requiredFeatures.indexOf("alignEUS") >= 0 ||
+			optionalFeatures.indexOf("alignEUS") >= 0) {
+			ARKitOptions.alignEUS = true;
 		}
 		let initResult = await this._arKitWrapper.waitForInit().then(() => {
 		}).catch((...params) => {
@@ -112,7 +123,9 @@ export default class ARKitDevice extends PolyfilledXRDevice {
 		})
 
 		let watchResult = await this._arKitWrapper.watch(ARKitOptions).then((results) => {
-			const session = new Session(options.outputContext || null)
+			// Note: Commenting out options.outputContext for now because
+			//       I don't know what it's used for.
+			const session = new Session(/*options.outputContext ||*/ null)
 			this._sessions.set(session.id, session)
 			this._activeSession = session
 
@@ -171,7 +184,7 @@ export default class ARKitDevice extends PolyfilledXRDevice {
 
 	requestFrameOfReferenceTransform(type, options){
 		var that = this
-        return new Promise((resolve, reject) => {
+		return new Promise((resolve, reject) => {
 			let enqueueOrExec = function (callback) {
 				if (that._baseFrameSet) {
 					callback()
@@ -181,17 +194,17 @@ export default class ARKitDevice extends PolyfilledXRDevice {
 			}
 
 			switch(type){
-				case 'head-model':
+				case 'viewer':
 					enqueueOrExec(function () { 
 						resolve(that._headModelMatrix) 
 					})
 					return
-				case 'eye-level':
+				case 'local':
 					enqueueOrExec(function () { 
 						resolve(that._eyeLevelMatrix) 
 					})
 					return
-				case 'stage':
+				case 'stage': // @TODO: Update
 					//return that._stageMatrix
 					reject(new Error('stage not supported', type))
 				default:


### PR DESCRIPTION
Following #29 

This PR updates `ARKitDevice.js` to follow the latest WebXR API spec.

The changes in this PR are
- Replace `PolyfilledXRDevice` with `XRDevice` to follow the latest the official webxr-polyfill API
- Replace `supportsSession()` with `isSessionSupported()` for the latest WebXR API
- Take the second argument of `requestSession()` for the latest WebXR API. Expects `worldSensing` and other feature descriptors are passed via this new argument
- Replace `XRReferenceSpaceType` keys from `head-model` and `eye-level` to `viewer` and `local`

Regarding `XRReferenceSpaceType` keys, I read old and new [WebXR API spec](https://immersive-web.github.io/webxr/#xrreferencespace-interface) and I guessed from the following descriptions that we can likely simply convert the keys. Does it sound good to you?

head-model

> An XRFrameOfReference with a frame of reference type of XRFrameOfReferenceType "head-model" describes a coordinate system identical to an XRFrameOfReferenceType/eye-level frame of reference, but where the device is always located at the origin. Any translation is provided by a software estimate of the devices position based solely on the device orientation and the assumption that the device is being worn as a headset. The translation estimate SHOULD be based off of modeling how the human head moves on average when an individual is only moving their neck.

eye-level

>  Passing a type of XRReferenceSpaceType eye-level creates an XRReferenceSpace instance. It represents a tracking space with a native origin near the user's head at the time of creation. The exact position and orientation will be initialized based on the conventions of the underlying platform. When using this reference space the user is not expected to move beyond their initial position much, if at all, and tracking is optimized for that purpose. For devices with 6DoF tracking, eye-level reference spaces should emphasize keeping the origin stable relative to the user's environment.


viewer

> Passing a type of viewer creates an XRReferenceSpace instance. It represents a tracking space with a native origin which tracks the position and orientation of the viewer. Every XRSession MUST support "viewer" XRReferenceSpaces.

local

> Passing a type of local creates an XRReferenceSpace instance. It represents a tracking space with a native origin near the viewer at the time of creation. The exact position and orientation will be initialized based on the conventions of the underlying platform. When using this reference space the user is not expected to move beyond their initial position much, if at all, and tracking is optimized for that purpose. For devices with 6DoF tracking, local reference spaces should emphasize keeping the origin stable relative to the user’s environment.
