### PR TITLE
Update Hit test API

### DIFF
--- a/src/webxr.js
+++ b/src/webxr.js
@@ -58,18 +58,34 @@ function _getWorldInformation () {
 	 return  _arKitWrapper.getWorldInformation()
 }
 
+/**
+ * Note: Following the spec in https://github.com/immersive-web/anchors/blob/master/explainer.md
+ *       There seems being a newer spec https://github.com/immersive-web/hit-test/blob/master/hit-testing-explainer.md
+ *       but it requires a big change and doesn't seemd to be fixed. So using the older spec for now.
+ *
+ * Note: In the spec, requestHitTest() takes two arguments - XRRay and XRCoordinateSystem.
+ *       But _xrSessionRequestHitTest() takes three arguments - Float32Array, XRReferenceSpace, and XRFrame
+ *       Because 1. old implementation takes Float32Array instead of XRRay so just following that
+ *       2. No XRCoordinateSyatem in the newest WebXR API and we should use XRReferenceSpace instead
+ *       3. in the newest WebXR API we use XRFrame.getPose() to get the pose of space relative to baseSpace.
+ *       Then adding the third argument frame {XRFrame} here as temporal workaround.
+ *       We should update to follow the spec if the hit test spec is updated.
+ *
+ * @param direction {Float32Array} @TODO: shoud be XRRay? 
+ * @param referenceSpace {XRReferenceSpace}
+ * @param frame {XRFrame}
+ * @return {Promise<FrozenArray<XRHitResult>>}
+ */
 // This will be XRSession.requestHitTest
-async function _xrSessionRequestHitTest(origin, direction, coordinateSystem) {
-	// Promise<FrozenArray<XRHitResult>> requestHitTest(Float32Array origin, Float32Array direction, XRCoordinateSystem coordinateSystem);
-
+async function _xrSessionRequestHitTest(direction, referenceSpace, frame) {
 	// ARKit only handles hit testing from the screen, so only head model FoR is accepted
-	if(coordinateSystem.type !== 'head-model'){
+	// Note: XRReferenceSpace doesn't have exposed type attribute now
+	//       so commenting out so far.
+	/*
+	if(referenceSpace.type !== 'head-model'){
 		return Promise.reject('Only head-model hit testing is supported')
 	}
-
-	if(origin[0] != 0.0 && origin[1] != 0.0 && origin[2] != 0.0) {
-		return Promise.reject('Platform only supports hit testing with ray origin = [0,0,0]')
-	}
+	*/
 
 	return new Promise((resolve, reject) => {
 		const normalizedScreenCoordinates = _convertRayToARKitScreenCoordinates(direction, _arKitWrapper._projectionMatrix)
@@ -84,11 +100,11 @@ async function _xrSessionRequestHitTest(origin, direction, coordinateSystem) {
 			// uncomment if you want one hit, and get rid of map below
 			// const hit = _arKitWrapper.pickBestHit(hits)
 
-			this.requestFrameOfReference('eye-level').then(eyeLevelFrameOfReference => {
-				eyeLevelFrameOfReference.getTransformTo(coordinateSystem, _workingMatrix)
+			this.requestReferenceSpace('local').then(localReferenceSpace => {
+				mat4.copy(_workingMatrix, frame.getPose(referenceSpace, localReferenceSpace).transform.matrix);
 				//console.log('eye to head', mat4.getTranslation(vec3.create(), csTransform), mat4.getRotation(new Float32Array(4), csTransform))
 				resolve(hits.map(hit => {
-					mat4.multiply(_workingMatrix2, _workingMatrix, hit.world_transform)
+					mat4.multiply(_workingMatrix2, _workingMatrix, hit.world_transform);
 					//console.log('world transform', mat4.getTranslation(vec3.create(), hit.world_transform), mat4.getRotation(new Float32Array(4), hit.world_transform))
 					//console.log('head transform', mat4.getTranslation(vec3.create(), hitInHeadMatrix), mat4.getRotation(new Float32Array(4), hitInHeadMatrix))
 					return new XRHitResult(_workingMatrix2, hit, _arKitWrapper._timestamp)
@@ -96,7 +112,7 @@ async function _xrSessionRequestHitTest(origin, direction, coordinateSystem) {
 			}).catch((...params) => {
 				console.error('Error testing for hits', ...params)
 				reject()
-			})
+			});
 		}).catch((...params) => {
 			console.error('Error testing for hits', ...params)
 			reject()


### PR DESCRIPTION
Following #30 

This  PR updates Hit test API based on https://github.com/immersive-web/anchors/blob/master/explainer.md, not on https://github.com/immersive-web/hit-test/blob/master/hit-testing-explainer.md. See the note comment in the code for the detail about workaround.