### PR TITLE
Prevents global names pollution by shim

### DIFF
--- a/xrshim.js
+++ b/xrshim.js
@@ -1,32 +1,31 @@
-const REALAPI_URL = 'https://raw.githack.com/MozillaReality/webxr-ios-js/develop/dist/webxr.js';
+{
+	const REALAPI_URL = 'https://raw.githack.com/MozillaReality/webxr-ios-js/develop/dist/webxr.js';
 
-// @TODO: Delete FakeXR class definition when the polyfill is loaded (possible?)
-class FakeXR {
-	isSessionSupported(mode) {
-		// Note: We support only immersive-ar mode for now.
-		//       See https://github.com/MozillaReality/webxr-ios-js/pull/34#discussion_r334910337
-		return Promise.resolve(mode === 'immersive-ar');
-	}
-	requestSession(mode, opts) {
-		console.log("going to load from ", REALAPI_URL)
-		return new Promise((resolve, reject) => {
-			delete window.navigator.xr;
-			const script = document.createElement('script');
-			script.setAttribute('src', REALAPI_URL);
-			script.setAttribute('type', 'text/javascript');
+	window.navigator.xr = {
+		isSessionSupported: function(mode) {
+			// Note: We support only immersive-ar mode for now.
+			//       See https://github.com/MozillaReality/webxr-ios-js/pull/34#discussion_r334910337
+			return Promise.resolve(mode === 'immersive-ar');
+		},
+		requestSession: function(mode, opts) {
+			console.log("going to load from ", REALAPI_URL)
+			return new Promise((resolve, reject) => {
+				delete window.navigator.xr;
+				const script = document.createElement('script');
+				script.setAttribute('src', REALAPI_URL);
+				script.setAttribute('type', 'text/javascript');
 
-			let loaded = false;
-			const loadFunction = () => {
-				if (loaded) return;
-				loaded = true;
-				console.log("now the script is really loaded", navigator.xr);
-				navigator.xr.requestSession(mode, opts).then(resolve).catch(reject);
-			};
-			script.onload = loadFunction;
-			script.onreadystatechange = loadFunction;
-			document.getElementsByTagName("head")[0].appendChild(script);
-		});
-	}
+				let loaded = false;
+				const loadFunction = () => {
+					if (loaded) return;
+					loaded = true;
+					console.log("now the script is really loaded", navigator.xr);
+					navigator.xr.requestSession(mode, opts).then(resolve).catch(reject);
+				};
+				script.onload = loadFunction;
+				script.onreadystatechange = loadFunction;
+				document.getElementsByTagName("head")[0].appendChild(script);
+			});
+		}
+	};
 }
-
-window.navigator.xr = new FakeXR();


### PR DESCRIPTION
Currently shim pollutes global names with `REALAPI_URL` and `FakeXR`. This update prevents the pollution.

(Just in case this updates is not related to #58)