### PR TITLE
Update Anchor API

### DIFF
--- a/examples/ar_anchors/index.html
+++ b/examples/ar_anchors/index.html
@@ -118,7 +118,7 @@
 					mat4.getTranslation(workingVec3, workingMatrix1);
 					mat4.fromTranslation(workingMatrix1, workingVec3);
 
-					const anchor = await session.addAnchor(workingMatrix1, localReferenceSpace, frame);
+					const anchor = await frame.addAnchor(workingMatrix1, localReferenceSpace);
 					engine.addAnchoredNode(anchor, engine.root);
 
 					// Kick off rendering
@@ -147,7 +147,7 @@
 				mat4.multiply(workingMatrix1, workingMatrix2, workingMatrix1);
 
 				// create an anchor in front of the phone
-				session.addAnchor(workingMatrix1, viewerReferenceSpace, frame).then(anchor => {					
+				frame.addAnchor(workingMatrix1, viewerReferenceSpace).then(anchor => {
 					engine.addAnchoredNode(anchor, createSceneGraphNode());					
 				}).catch(err => {
 					console.error('Error adding anchor', err);

--- a/examples/ar_simplest/index.html
+++ b/examples/ar_simplest/index.html
@@ -96,7 +96,7 @@
 					mat4.getTranslation(workingVec3, workingMatrix);
 					mat4.fromTranslation(workingMatrix, workingVec3);
 
-					const anchor = await session.addAnchor(workingMatrix, localReferenceSpace, frame);
+					const anchor = await frame.addAnchor(workingMatrix, localReferenceSpace);
 					engine.addAnchoredNode(anchor, engine.root);
 
 					// Kick off rendering

--- a/examples/boombox/index.html
+++ b/examples/boombox/index.html
@@ -130,7 +130,7 @@
 					mat4.getTranslation(workingVec3, workingMatrix);
 					mat4.fromTranslation(workingMatrix, workingVec3);
 
-					const anchor = await session.addAnchor(workingMatrix, localReferenceSpace, frame);
+					const anchor = await frame.addAnchor(workingMatrix, localReferenceSpace);
 					engine.addAnchoredNode(anchor, engine.root);
 
 					// Kick off rendering

--- a/examples/face_tracking/index.html
+++ b/examples/face_tracking/index.html
@@ -347,7 +347,7 @@
 			mat4.getTranslation(workingVec3, workingMatrix);
 			mat4.fromTranslation(workingMatrix, workingVec3);
 
-			const anchor = await session.addAnchor(workingMatrix, localReferenceSpace, frame);
+			const anchor = await frame.addAnchor(workingMatrix, localReferenceSpace);
 			engine.addAnchoredNode(anchor, engine.root);
 
 			session.requestAnimationFrame(handleAnimationFrame)

--- a/examples/hit_test/index.html
+++ b/examples/hit_test/index.html
@@ -94,7 +94,7 @@
 				let size = 0.05;
 				if (hits.length > 0) {
 					const hit = hits[0];
-					session.addAnchor(hit, localReferenceSpace, frame).then(anchor => {
+					frame.addAnchor(hit, localReferenceSpace).then(anchor => {
 						engine.addAnchoredNode(anchor, createSceneGraphNode());
 					}).catch(err => {
 						console.error('Error adding anchor', err);
@@ -152,7 +152,7 @@
 					mat4.getTranslation(workingVec3, workingMatrix)
 					mat4.fromTranslation(workingMatrix, workingVec3)
 
-					const anchor = await session.addAnchor(workingMatrix, localReferenceSpace, frame);
+					const anchor = await frame.addAnchor(workingMatrix, localReferenceSpace);
 					engine.addAnchoredNode(anchor, engine.root);
 				
 					// Kick off rendering

--- a/examples/image_detection/index.html
+++ b/examples/image_detection/index.html
@@ -106,7 +106,7 @@
 					imageActivateDetection = true;
 					//engine.removeAnchoredNode(ducky)
 					if (imageAnchor) {
-						session.removeAnchor(imageAnchor);
+						imageAnchor.detach();
 						engine.removeAnchoredNode(ducky);
 						imageAnchor = null;
 					}
@@ -217,7 +217,7 @@
 			mat4.getTranslation(workingVec3, workingMatrix);
 			mat4.fromTranslation(workingMatrix, workingVec3);
 
-			const anchor = await session.addAnchor(workingMatrix, localReferenceSpace, frame);
+			const anchor = await frame.addAnchor(workingMatrix, localReferenceSpace);
 			engine.addAnchoredNode(anchor, engine.root);
 
 			// Kick off rendering

--- a/examples/light/index.html
+++ b/examples/light/index.html
@@ -179,7 +179,7 @@
 					mat4.getTranslation(workingVec3, workingMatrix);
 					mat4.fromTranslation(workingMatrix, workingVec3);
 
-					const anchor = await session.addAnchor(workingMatrix, localReferenceSpace, frame);
+					const anchor = await frame.addAnchor(workingMatrix, localReferenceSpace);
 					engine.addAnchoredNode(anchor, engine.root);
 
 					// Kick off rendering

--- a/examples/peoples/index.html
+++ b/examples/peoples/index.html
@@ -287,7 +287,7 @@
 				const size = 0.05;
 				if (hits.length > 0) {
 					const hit = hits[0];
-					session.addAnchor(hit, viewerReferenceSpace, frame).then(anchor => {					
+					frame.addAnchor(hit, viewerReferenceSpace).then(anchor => {
 						engine.addAnchoredNode(anchor, createSceneGraphNode());
 					}).catch(err => {
 						console.error('Error adding anchor', err);
@@ -323,7 +323,7 @@
 					mat4.getTranslation(workingVec3, workingMatrix);
 					mat4.fromTranslation(workingMatrix, workingVec3);
 
-					const anchor = await session.addAnchor(workingMatrix, localReferenceSpace, frame);
+					const anchor = await frame.addAnchor(workingMatrix, localReferenceSpace);
 					engine.addAnchoredNode(anchor, engine.root);
 
 

--- a/examples/reticle/index.html
+++ b/examples/reticle/index.html
@@ -177,7 +177,7 @@
 					mat4.getTranslation(workingVec3, workingMatrix);
 					mat4.fromTranslation(workingMatrix, workingVec3);
 
-					const anchor = await session.addAnchor(workingMatrix, localReferenceSpace, frame);
+					const anchor = await frame.addAnchor(workingMatrix, localReferenceSpace);
 					engine.addAnchoredNode(anchor, engine.root);
 
 					// Kick off rendering

--- a/examples/sensing/index.html
+++ b/examples/sensing/index.html
@@ -353,7 +353,7 @@
 				mat4.getTranslation(workingVec3, workingMatrix);
 				mat4.fromTranslation(workingMatrix, workingVec3);
 
-				const anchor = await session.addAnchor(workingMatrix, localReferenceSpace, frame);
+				const anchor = await frame.addAnchor(workingMatrix, localReferenceSpace);
 				engine.addAnchoredNode(anchor, engine.root);
 
 				// Kick off rendering

--- a/src/extensions/XRAnchor.js
+++ b/src/extensions/XRAnchor.js
@@ -89,6 +89,9 @@ export default class XRAnchor extends EventTarget {
 	static _generateUID(){
 		return 'anchor-' + new Date().getTime() + '-' + Math.floor((Math.random() * Number.MAX_SAFE_INTEGER))
 	}
+
+	// Note: detach() is defined in webxr.js.
+	// detach() {}
 }
 
 // need to implement events


### PR DESCRIPTION
Resolves #65 

This PR updates webxr-ios-js to follow the newest Anchor API spec https://github.com/immersive-web/anchors

The changes are
- Move addAnchor() from XRSession to XRFrame
- Move from XRSession.removeAnchor() to XRAnchor.detach()
- Update examples to follow the above changes