### PR TITLE
Fix input pose calculation

### DIFF
--- a/src/arkit/ARKitDevice.js
+++ b/src/arkit/ARKitDevice.js
@@ -687,11 +687,16 @@ export default class ARKitDevice extends XRDevice {
 		for (let i = 0; i < this._gamepadInputSources.length; i++) {
 			const inputSourceImpl = this._gamepadInputSources[i];
 			if (inputSourceImpl.active && inputSourceImpl.inputSource === inputSource) {
-				// @TODO: Support Transient input
+				const fov = 2.0 * Math.atan(1.0 / this._projectionMatrix[5]);
+				const halfFov = fov * 0.5;
+				const near = this._projectionMatrix[14] / (this._projectionMatrix[10] - 1.0);
+				const aspect = this._projectionMatrix[5] / this._projectionMatrix[0];
+
 				const deviceWidth = document.documentElement.clientWidth;
 				const deviceHeight = document.documentElement.clientHeight;
 				const clientX = this._touches[i].x;
 				const clientY = this._touches[i].y;
+
 				// convert to -1.0 to 1.0
 				const normalizedX = (clientX / deviceWidth) * 2.0 - 1.0;
 				const normalizedY = -(clientY / deviceHeight) * 2.0 + 1.0;
@@ -700,12 +705,12 @@ export default class ARKitDevice extends XRDevice {
 				// @TODO: Optimize if possible
 				const viewMatrixInverse = mat4.invert(mat4.create(), this._headModelMatrix);
 				coordinateSystem._transformBasePoseMatrix(viewMatrixInverse, viewMatrixInverse);
+
 				const matrix = mat4.identity(mat4.create());
-				// Assuming FOV is 90 degree @TODO: Remove this constraint
-				const near = 0.1; // @TODO: Should be from render state
-				const aspect = deviceWidth / deviceHeight;
-				matrix[12] = normalizedX * near * aspect;
-				matrix[13] = normalizedY * near;
+				mat4.rotateY(matrix, matrix, -normalizedX * halfFov * aspect);
+				mat4.rotateX(matrix, matrix, normalizedY * halfFov);
+				matrix[12] = normalizedX * Math.tan(halfFov) * near * aspect;
+				matrix[13] = normalizedY * Math.tan(halfFov) * near;
 				matrix[14] = -near;
 				mat4.multiply(matrix, viewMatrixInverse, matrix);
 


### PR DESCRIPTION
This PR fixes input pose calculation. The current implementation assumes FOV is always 90 degree and input pose will be wrong if FOV of a device is not 90 degree. So this PR extracts FOV from the projection matrix passed from the device. 